### PR TITLE
Set location as a ps1 argument

### DIFF
--- a/labs/lab03/deployment-script-lab03.ps1
+++ b/labs/lab03/deployment-script-lab03.ps1
@@ -1,5 +1,5 @@
 # Parameters
-param([string] $location = "West Europe")
+param([string] $location = "East US")
 $newDeploymentName="AZ204Lab03Deployment"
 $resourceGroupName="StorageMedia"
 $storageAccountNameSuffix=Get-Random -Maximum 100000000

--- a/labs/lab03/deployment-script-lab03.ps1
+++ b/labs/lab03/deployment-script-lab03.ps1
@@ -1,7 +1,7 @@
 # Parameters
+param([string] $location = "West Europe")
 $newDeploymentName="AZ204Lab03Deployment"
 $resourceGroupName="StorageMedia"
-$location="East US"
 $storageAccountNameSuffix=Get-Random -Maximum 100000000
 
 $ParametersObj = @{


### PR DESCRIPTION
Changing the default location when running the script, e.g.
`./deployment-script-lab03.ps1 -location "West Europe"`
with no need to modify the code.
